### PR TITLE
Change Tokenizer require location to prevent errors with 'inline-requires' babel plugin.

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -1,4 +1,4 @@
-var Tokenizer = require("./Tokenizer.js");
+var Tokenizer;
 
 /*
 	Options:
@@ -113,6 +113,8 @@ function Parser(cbs, options){
 									!this._options.xmlMode;
 	if(!!this._options.Tokenizer) {
 		Tokenizer = this._options.Tokenizer;
+	} else {
+		Tokenizer = require("./Tokenizer.js");	
 	}
 	this._tokenizer = new Tokenizer(this._options, this);
 


### PR DESCRIPTION
Error message:

```
error: bundling failed: "TransformError: /Users/douglas/projetos/ReactNative/aquasafe-mobile/node_modules/htmlparser2-without-node-native/lib/Parser.js: /Users/douglas/projetos/ReactNative/aquasafe-mobile/node_modules/htmlparser2-without-node-native/lib/Parser.js: Cannot assign to a require(...) alias, Tokenizer. Line: 115."
```

Plugin source: https://github.com/facebook/fbjs/blob/master/packages/babel-preset-fbjs/plugins/inline-requires.js